### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-storagecache

### DIFF
--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/StorageCache/back-compatible.tsp
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/StorageCache/back-compatible.tsp
@@ -33,63 +33,63 @@ using Microsoft.StorageCache;
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(AscOperation.properties);
 
-@@clientLocation(AmlFilesystems.get, "amlFilesystems");
-@@clientLocation(AmlFilesystems.createOrUpdate, "amlFilesystems");
+@@clientLocation(AmlFilesystems.get, "AmlFilesystems");
+@@clientLocation(AmlFilesystems.createOrUpdate, "AmlFilesystems");
 @@clientName(AmlFilesystems.createOrUpdate::parameters.resource,
   "amlFilesystem"
 );
-@@clientLocation(AmlFilesystems.update, "amlFilesystems");
+@@clientLocation(AmlFilesystems.update, "AmlFilesystems");
 @@clientName(AmlFilesystems.update::parameters.properties, "amlFilesystem");
-@@clientLocation(AmlFilesystems.delete, "amlFilesystems");
-@@clientLocation(AmlFilesystems.listByResourceGroup, "amlFilesystems");
-@@clientLocation(AmlFilesystems.list, "amlFilesystems");
-@@clientLocation(AmlFilesystems.archive, "amlFilesystems");
+@@clientLocation(AmlFilesystems.delete, "AmlFilesystems");
+@@clientLocation(AmlFilesystems.listByResourceGroup, "AmlFilesystems");
+@@clientLocation(AmlFilesystems.list, "AmlFilesystems");
+@@clientLocation(AmlFilesystems.archive, "AmlFilesystems");
 @@clientName(AmlFilesystems.archive::parameters.body, "archiveInfo");
-@@clientLocation(AmlFilesystems.cancelArchive, "amlFilesystems");
+@@clientLocation(AmlFilesystems.cancelArchive, "AmlFilesystems");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(AmlFilesystem.properties);
 
-@@clientLocation(AutoExportJobs.get, "autoExportJobs");
-@@clientLocation(AutoExportJobs.createOrUpdate, "autoExportJobs");
+@@clientLocation(AutoExportJobs.get, "AutoExportJobs");
+@@clientLocation(AutoExportJobs.createOrUpdate, "AutoExportJobs");
 @@clientName(AutoExportJobs.createOrUpdate::parameters.resource,
   "autoExportJob"
 );
-@@clientLocation(AutoExportJobs.update, "autoExportJobs");
+@@clientLocation(AutoExportJobs.update, "AutoExportJobs");
 @@clientName(AutoExportJobs.update::parameters.properties, "autoExportJob");
-@@clientLocation(AutoExportJobs.delete, "autoExportJobs");
-@@clientLocation(AutoExportJobs.listByAmlFilesystem, "autoExportJobs");
+@@clientLocation(AutoExportJobs.delete, "AutoExportJobs");
+@@clientLocation(AutoExportJobs.listByAmlFilesystem, "AutoExportJobs");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(AutoExportJob.properties);
 
-@@clientLocation(ImportJobs.get, "importJobs");
-@@clientLocation(ImportJobs.createOrUpdate, "importJobs");
+@@clientLocation(ImportJobs.get, "ImportJobs");
+@@clientLocation(ImportJobs.createOrUpdate, "ImportJobs");
 @@clientName(ImportJobs.createOrUpdate::parameters.resource, "importJob");
-@@clientLocation(ImportJobs.update, "importJobs");
+@@clientLocation(ImportJobs.update, "ImportJobs");
 @@clientName(ImportJobs.update::parameters.properties, "importJob");
-@@clientLocation(ImportJobs.delete, "importJobs");
-@@clientLocation(ImportJobs.listByAmlFilesystem, "importJobs");
+@@clientLocation(ImportJobs.delete, "ImportJobs");
+@@clientLocation(ImportJobs.listByAmlFilesystem, "ImportJobs");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(ImportJob.properties);
 
-@@clientLocation(AutoImportJobs.get, "autoImportJobs");
-@@clientLocation(AutoImportJobs.createOrUpdate, "autoImportJobs");
+@@clientLocation(AutoImportJobs.get, "AutoImportJobs");
+@@clientLocation(AutoImportJobs.createOrUpdate, "AutoImportJobs");
 @@clientName(AutoImportJobs.createOrUpdate::parameters.resource,
   "autoImportJob"
 );
-@@clientLocation(AutoImportJobs.update, "autoImportJobs");
+@@clientLocation(AutoImportJobs.update, "AutoImportJobs");
 @@clientName(AutoImportJobs.update::parameters.properties, "autoImportJob");
-@@clientLocation(AutoImportJobs.delete, "autoImportJobs");
-@@clientLocation(AutoImportJobs.listByAmlFilesystem, "autoImportJobs");
+@@clientLocation(AutoImportJobs.delete, "AutoImportJobs");
+@@clientLocation(AutoImportJobs.listByAmlFilesystem, "AutoImportJobs");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(AutoImportJob.properties);
 
-@@clientLocation(ExpansionJobs.get, "expansionJobs");
-@@clientLocation(ExpansionJobs.createOrUpdate, "expansionJobs");
+@@clientLocation(ExpansionJobs.get, "ExpansionJobs");
+@@clientLocation(ExpansionJobs.createOrUpdate, "ExpansionJobs");
 @@clientName(ExpansionJobs.createOrUpdate::parameters.resource, "expansionJob");
-@@clientLocation(ExpansionJobs.update, "expansionJobs");
+@@clientLocation(ExpansionJobs.update, "ExpansionJobs");
 @@clientName(ExpansionJobs.update::parameters.properties, "expansionJob");
-@@clientLocation(ExpansionJobs.delete, "expansionJobs");
-@@clientLocation(ExpansionJobs.listByAmlFilesystem, "expansionJobs");
+@@clientLocation(ExpansionJobs.delete, "ExpansionJobs");
+@@clientLocation(ExpansionJobs.listByAmlFilesystem, "ExpansionJobs");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(ExpansionJob.properties);
 

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/StorageCache/client.tsp
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/StorageCache/client.tsp
@@ -2,8 +2,13 @@ import "@azure-tools/typespec-client-generator-core";
 import "./main.tsp";
 
 using Azure.ClientGenerator.Core;
+using Microsoft.StorageCache;
 
 @@clientName(Microsoft.StorageCache,
   "StorageCacheManagementClient",
   "javascript"
+);
+@@clientName(Microsoft.StorageCache,
+  "StorageCacheManagementClient",
+  "python"
 );

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/StorageCache/tspconfig.yaml
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/StorageCache/tspconfig.yaml
@@ -1,46 +1,47 @@
-parameters:
-  "service-dir":
-    default: "sdk/storagecache"
 emit:
-  - "@azure-tools/typespec-autorest"
-options:
-  "@azure-tools/typespec-autorest":
-    omit-unreachable-types: true
-    emitter-output-dir: "{project-root}"
-    azure-resource-provider-folder: "resource-manager"
-    output-file: "{version-status}/{version}/openapi.json"
-    arm-types-dir: "{project-root}/../../../../common-types/resource-management"
-    emit-lro-options: "all"
-    examples-dir: "{project-root}/examples"
-  "@azure-tools/typespec-python":
-    emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-storagecache"
-    namespace: "azure.mgmt.storagecache"
-    generate-test: true
-    generate-sample: true
-    flavor: "azure"
-  "@azure-tools/typespec-java":
-    emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-storagecache"
-    namespace: "com.azure.resourcemanager.storagecache"
-    service-name: "StorageCache" # human-readable service name, whitespace allowed
-    flavor: azure
-  "@azure-tools/typespec-ts":
-    service-dir: sdk/storagecache
-    emitter-output-dir: "{output-dir}/{service-dir}/arm-storagecache"
-    compatibility-lro: true
-    flavor: "azure"
-    experimental-extensible-enums: true
-    package-details:
-      name: "@azure/arm-storagecache"
-  "@azure-tools/typespec-go":
-    service-dir: "sdk/resourcemanager/storagecache"
-    emitter-output-dir: "{output-dir}/{service-dir}/armstoragecache"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armstoragecache"
-    fix-const-stuttering: true
-    flavor: "azure"
-    generate-samples: true
-    generate-fakes: true
-    head-as-boolean: true
-    inject-spans: true
+- '@azure-tools/typespec-autorest'
 linter:
   extends:
-    - "@azure-tools/typespec-azure-rulesets/resource-manager"
+  - '@azure-tools/typespec-azure-rulesets/resource-manager'
+options:
+  '@azure-tools/typespec-autorest':
+    arm-types-dir: '{project-root}/../../../../common-types/resource-management'
+    azure-resource-provider-folder: resource-manager
+    emit-lro-options: all
+    emitter-output-dir: '{project-root}'
+    examples-dir: '{project-root}/examples'
+    omit-unreachable-types: true
+    output-file: '{version-status}/{version}/openapi.json'
+  '@azure-tools/typespec-go':
+    emitter-output-dir: '{output-dir}/{service-dir}/armstoragecache'
+    fix-const-stuttering: true
+    flavor: azure
+    generate-fakes: true
+    generate-samples: true
+    head-as-boolean: true
+    inject-spans: true
+    module: github.com/Azure/azure-sdk-for-go/{service-dir}/armstoragecache
+    service-dir: sdk/resourcemanager/storagecache
+  '@azure-tools/typespec-java':
+    emitter-output-dir: '{output-dir}/{service-dir}/azure-resourcemanager-storagecache'
+    flavor: azure
+    namespace: com.azure.resourcemanager.storagecache
+    service-name: StorageCache
+  '@azure-tools/typespec-python':
+    api-version: '2026-01-01'
+    emitter-output-dir: '{output-dir}/{service-dir}/azure-mgmt-storagecache'
+    flavor: azure
+    generate-sample: true
+    generate-test: true
+    namespace: azure.mgmt.storagecache
+  '@azure-tools/typespec-ts':
+    compatibility-lro: true
+    emitter-output-dir: '{output-dir}/{service-dir}/arm-storagecache'
+    experimental-extensible-enums: true
+    flavor: azure
+    package-details:
+      name: '@azure/arm-storagecache'
+    service-dir: sdk/storagecache
+parameters:
+  service-dir:
+    default: sdk/storagecache


### PR DESCRIPTION
# [Python] Mitigate breaking changes for azure-mgmt-storagecache

## Breaking Changes Classification

| # | Breaking Change | Classification | Mitigation |
|---|---|---|---|
| 1 | Deleted or renamed client `StorageCacheManagementClient` | **MITIGATE** | `@@clientName(Microsoft.StorageCache, "StorageCacheManagementClient", "python")` in `client.tsp` |
| 2 | Model `Restriction` deleted or renamed its instance variable `values` | ACCEPT | Category 12: reserved name conflict (`values` → `values_property`) |
| 3 | Deleted or renamed model `ResourceSkusResult` | ACCEPT | Category 8: pageable model removal |
| 4 | Deleted or renamed model `StorageTargetResource` | ACCEPT | Category 7: unreferenced model removal |
| 5 | Deleted or renamed model `StorageTargetsResult` | ACCEPT | Category 8: pageable model removal |
| 6 | Deleted or renamed model `UsageModelsResult` | ACCEPT | Category 8: pageable model removal |
| 7 | Deleted or renamed model `UserAssignedIdentitiesValueAutoGenerated` | ACCEPT | Category 6/7: common types upgrade |
| 8 | `StorageTargetsOperations.begin_delete` param `force` changed to keyword_only | ACCEPT | Category 9: positional → keyword-only |
| 9 | Deleted or renamed model `AmlFilesystemsOperations` | **MITIGATE** | Fixed `@@clientLocation` value from camelCase to PascalCase in `back-compatible.tsp` |
| 10 | Deleted or renamed model `AutoExportJobsOperations` | **MITIGATE** | Same as above |
| 11 | Deleted or renamed model `AutoImportJobsOperations` | **MITIGATE** | Same as above |
| 12 | Deleted or renamed model `ExpansionJobsOperations` | **MITIGATE** | Same as above |
| 13 | Deleted or renamed model `ImportJobsOperations` | **MITIGATE** | Same as above |

## Summary

- **Mitigated:** 6 (client rename + 5 operation group renames)
- **Accepted:** 7 (pageable models, unreferenced models, common types, reserved name conflict, keyword-only params)

## Remaining Accepted Breaking Changes

- Model `Restriction` instance variable `values` renamed to `values_property` (reserved name conflict)
- Removed pageable models: `ResourceSkusResult`, `StorageTargetsResult`, `UsageModelsResult`
- Removed unreferenced model: `StorageTargetResource`
- Removed common type: `UserAssignedIdentitiesValueAutoGenerated`
- Parameter `force` in `StorageTargetsOperations.begin_delete` changed to keyword-only
