### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-security

### DIFF
--- a/specification/security/resource-manager/Microsoft.Security/Security/client.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/client.tsp
@@ -328,6 +328,26 @@ op privateLinkResourcesGetCustomization(
   "python"
 );
 
+// Python SDK breaking change mitigations for TypeSpec migration
+
+// Category 4: Client name - restore swagger title "SecurityCenter"
+@@clientName(SecurityManagementClient, "SecurityCenter", "python");
+
+// Category 3: Enum renames from swagger directives in readme.python.md
+@@clientName(SecuritySolutionsAPI.AadConnectivityState,
+  "AadConnectivityStateEnum",
+  "python"
+);
+@@clientName(SecuritySolutionsAPI.ExternalSecuritySolutionKind,
+  "ExternalSecuritySolutionKindEnum",
+  "python"
+);
+@@clientName(SecuritySolutionsAPI.Protocol, "ProtocolEnum", "python");
+@@clientName(AlertsAPI.Kind, "KindEnum", "python");
+
+// Name collision: Status union collides with Status model from another sub-service
+@@clientName(SecuritySolutionsAPI.Status, "StatusEnum", "python");
+
 @@clientName(Azure.ResourceManager.CommonTypes.ErrorAdditionalInfo,
   "ArmErrorAdditionalInfo",
   "java"


### PR DESCRIPTION
# [Python] Mitigate breaking changes for azure-mgmt-security

Spec PR: https://github.com/Azure/azure-rest-api-specs/pull/41888

This PR adds `@@clientName` decorators to `client.tsp` to mitigate Python SDK breaking changes during TypeSpec migration.

## Mitigations Applied

| Breaking Change | Classification | Mitigation |
|---|---|---|
| Client renamed from `SecurityCenter` to `SecurityManagementClient` | MITIGATE | `@@clientName(SecurityManagementClient, "SecurityCenter", "python")` |
| Enum `AadConnectivityStateEnum` renamed to `AadConnectivityState` | MITIGATE | `@@clientName(SecuritySolutionsAPI.AadConnectivityState, "AadConnectivityStateEnum", "python")` |
| Enum `ExternalSecuritySolutionKindEnum` renamed to `ExternalSecuritySolutionKind` | MITIGATE | `@@clientName(SecuritySolutionsAPI.ExternalSecuritySolutionKind, "ExternalSecuritySolutionKindEnum", "python")` |
| Enum `ProtocolEnum` renamed to `Protocol` | MITIGATE | `@@clientName(SecuritySolutionsAPI.Protocol, "ProtocolEnum", "python")` |
| Enum `KindEnum` renamed to `Kind` | MITIGATE | `@@clientName(AlertsAPI.Kind, "KindEnum", "python")` |
| Enum `Status` collides with model `Status` | MITIGATE | `@@clientName(SecuritySolutionsAPI.Status, "StatusEnum", "python")` |

## Accepted Breaking Changes (no mitigation needed)

These are expected changes from TypeSpec migration and are accepted per the [breaking changes guide](https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/mgmt/sdk-breaking-changes-guide.md):

- **~140 pageable models removed** (e.g., `AlertList`, `PricingList`) — Category 8
- **~40 common type/error models removed** (e.g., `CloudErrorAutoGenerated*`) — Categories 6, 7
- **~19 models lost flattened properties** (e.g., `Pricing`, `IoTSecuritySolutionModel`) — Category 11
- **4 list methods changed from async to sync** — pagination design change
- **Enum string method noise** (`OperationResult.capitalize`, etc.) — code report artifact
- **`OperationResult` changed from enum to model** — structural TypeSpec change
- **IoT threshold subtypes removed** (e.g., `ActiveConnectionsNotInAllowedRange`) — unreferenced models

## Python codegen bug

The Python emitter (`@typespec/http-client-python@0.28.3`) has a bug where duplicate model names are generated for LRO operations with `@@override`. This causes `ValueError: We have already generated a schema with name createOrUpdateRequest`. A local pygen patch was applied to generate the SDK. This should be tracked as a bug in https://github.com/microsoft/typespec/issues.
